### PR TITLE
viewing shelf by non-logged in works

### DIFF
--- a/server/routes/shelf.router.js
+++ b/server/routes/shelf.router.js
@@ -6,7 +6,7 @@ const { rejectUnauthenticated } = require('../modules/authentication-middleware'
 /**
  * Get all of the items on the shelf
  */
-router.get('/', rejectUnauthenticated, (req, res) => {
+router.get('/',  (req, res) => {
   console.log('in get router')
   sqlText = `
   SELECT * FROM "item"`

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -60,13 +60,13 @@ function App() {
             <UserPage />
           </ProtectedRoute>
 
-          <ProtectedRoute
+          <Route
             // logged in shows InfoPage else shows LoginPage
             exact
             path="/shelf"
           >
             <ShelfPage />
-          </ProtectedRoute>
+          </Route>
 
           <Route
             exact

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -24,13 +24,13 @@ function Nav() {
         {/* If a user is logged in, show these links */}
         {user.id && (
           <>
-            <Link className="navLink" to="/shelf">
-              The Shelf
-            </Link>
+
             <LogOutButton className="navLink" />
           </>
         )}
-
+          <Link className="navLink" to="/shelf">
+            The Shelf
+          </Link>
         <Link className="navLink" to="/about">
           About
         </Link>

--- a/src/components/ShelfForm/ShelfForm.jsx
+++ b/src/components/ShelfForm/ShelfForm.jsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 
+
 function ShelfForm () {
 
     const dispatch = useDispatch();
-
     //fetches the user object from redux
     //The object keys are id and username
     const user = useSelector((store) => store.user )
@@ -45,27 +45,29 @@ function ShelfForm () {
 
 
     return (
-        <div>
-            <h2>Add Item to Shelf:</h2>
-            <form onSubmit={(event) => addItem(event)}>
-                <input 
-                    onChange={handleDescriptionChange}
-                    type = 'text'
-                    placeholder = 'Item Description'
-                    value = {itemToAdd.description}
-                />
+            <div>     
+                {user.id && (<>
+                    <h2>Add Item to Shelf:</h2>
+                    <form onSubmit={(event) => addItem(event)}>
+                        <input 
+                            onChange={handleDescriptionChange}
+                            type = 'text'
+                            placeholder = 'Item Description'
+                            value = {itemToAdd.description}
+                        />
 
-                <input 
-                    onChange={handleImageChange}
-                    type = 'text'
-                    placeholder = 'Item Image URL'
-                    value = {itemToAdd.image_url}
-                />
+                        <input 
+                            onChange={handleImageChange}
+                            type = 'text'
+                            placeholder = 'Item Image URL'
+                            value = {itemToAdd.image_url}
+                        />
 
-                <button type='submit'>Submit</button>
-            </form>
-        </div>
-
+                        <button type='submit'>Submit</button>
+                    </form>
+                    </>
+            )}
+             </div>
     )
 
 }

--- a/src/components/ShelfPage/ShelfPage.jsx
+++ b/src/components/ShelfPage/ShelfPage.jsx
@@ -25,7 +25,8 @@ useEffect (() => {
           return (
             <li key={shelfItems.id}>{shelfItems.description}
               <img className="itemImage" src={shelfItems.image_url}></img>
-              <button type="submit" onClick={() => {handleDelete(shelfItems.id)}}>Delete</button>
+              {store.user.id && ( 
+              <button type="submit" onClick={() => {handleDelete(shelfItems.id)}}>Delete</button>)}
               </li> 
           )
         })}


### PR DESCRIPTION
This works fine - I'm just not committing it so that you all can see what changed.

Took off 'rejectUnauthenticated' from the GET route so that the GET works even for non-logged in users
Also took off the ProtectedRoute on /shelf so it shows for everyone
we then rearranged "The Shelf" on the Nav bar so, once again, it shows even when noone is logged in.

Additionally, we used  {user.id &&   on the Add Item  and the delete button so that they will only show for logged in users.  The rejectUnauthenticated still exists on the router so they couldn't add or delete anyway.   
**This (the {user.id &&) should probably go on the Edit button once that gets merged in